### PR TITLE
chore(ui): ux cleanup — soften links & remove internal ops text

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -2,7 +2,8 @@
   --bg: 255 255 255;
   --text: 17 24 39;
   --muted: 99 102 106;
-  --accent: 10 132 255;
+  /* Softer accent for links: slightly desaturated and darker blue */
+  --accent: 48 102 173; /* rgb(48,102,173) */
   --card-bg: 250 250 250;
   --radius: 12px;
   --gap: 1.25rem;
@@ -15,7 +16,8 @@
     --text: 230 230 230;
     --muted: 148 163 184;
     --card-bg: 20 22 25;
-    --accent: 90 160 255;
+    /* Dark mode accent: toned down to match light-mode choice */
+    --accent: 96 150 212; /* rgb(96,150,212) */
   }
 }
 

--- a/projects/mini-llm/index.html
+++ b/projects/mini-llm/index.html
@@ -89,8 +89,8 @@ fetch('/api/s2/paper/ARXIV:2301.10140').then(r=>r.json()).then(console.log);
     </section>
     
     <section style="margin-top:1rem">
-      <h2>Backend proxy</h2>
-      <p class="muted">See the example proxy I included in <a href="/backend/README.md">/backend/README.md</a> — it shows a small FastAPI pattern for forwarding requests to Semantic Scholar while keeping your API key secret.</p>
+      <h2>Backend notes</h2>
+      <p class="muted">In production you should keep API keys server-side and use a small proxy to forward requests; this helps protect credentials and apply caching/rate limits. Implementation details are intentionally omitted from the public site.</p>
     </section>
   </main>
 </body>

--- a/projects/runway-fod/index.html
+++ b/projects/runway-fod/index.html
@@ -46,8 +46,8 @@
       <h2>Implementation notes</h2>
       <ul>
         <li>Edge deployment option with model quantization for onsite inference on near-runway cameras.</li>
-        <li>Cloud-based analytics for aggregated reporting, retraining, and model updates.</li>
-        <li>APIs for integrating with airport operations dashboards and maintenance ticketing systems.</li>
+        <li>Cloud analytics can be used for model updates and reporting; operational details are out of scope for this public summary.</li>
+        <li>APIs for integrating with airport operations dashboards and maintenance ticketing systems (integration specifics are implementation-dependent).</li>
       </ul>
     </section>
 


### PR DESCRIPTION
Softens site accent color and removes internal ops/architecture details from public project pages (mini-LLM, Runway FOD).